### PR TITLE
chore: Remove default config as fallback, optional resource and others

### DIFF
--- a/operator/api/v1alpha1/manifest_types.go
+++ b/operator/api/v1alpha1/manifest_types.go
@@ -54,7 +54,7 @@ type ManifestSpec struct {
 	CustomStates []types.CustomState `json:"customStates"`
 
 	//+kubebuilder:pruning:PreserveUnknownFields
-	//+kubebuilder:object:generate=false
+	// +kubebuilder:validation:Optional
 	// Resource specifies a resource to be watched for state updates
 	Resource unstructured.Unstructured `json:"resource"`
 

--- a/operator/config/crd/bases/component.kyma-project.io_manifests.yaml
+++ b/operator/config/crd/bases/component.kyma-project.io_manifests.yaml
@@ -144,7 +144,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - installs
-            - resource
             type: object
           status:
             description: Status signifies the current status of the Manifest

--- a/operator/config/crd/bases/sample_crd.yaml
+++ b/operator/config/crd/bases/sample_crd.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: samplecrds.component.kyma-project.io
+spec:
+  group: component.kyma-project.io
+  names:
+    kind: SampleCRD
+    listKind: SampleCRDList
+    plural: samplecrds
+    singular: samplecrd
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: SampleCRD is the Schema for a component API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of Sample CRD.
+              properties:
+                randomkey:
+                  description: Its random!
+                  type: string
+              required:
+                - randomkey
+              type: object
+            status:
+              description: Status defines the observed state of Sample CRD
+              properties:
+                state:
+                  description: State signifies current state of Sample CRD. Value can be one
+                    of ("Ready", "Processing", "Error", "Deleting").
+                  enum:
+                    - Processing
+                    - Deleting
+                    - Ready
+                    - Error
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operator/config/samples/component_v1alpha1_manifest.yaml
+++ b/operator/config/samples/component_v1alpha1_manifest.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: default
 spec:
   crds:
-    ref: sha256:58d0d837393f2e4db3b6febf26fa721479f03ccd36d5969998025a15c4a25a0d
+    ref: sha256:743134e30217d798d3dd36e76965800f90faddf9204d547a13363248b4ab473c
     name: kyma-project.io/module/example
     repo: k3d-registry.localhost:52445/signed/component-descriptors
     type: oci-ref

--- a/operator/controllers/manifest_controller.go
+++ b/operator/controllers/manifest_controller.go
@@ -164,7 +164,7 @@ func (r *ManifestReconciler) jobAllocator(ctx context.Context, logger *logr.Logg
 
 	// send deploy requests
 	deployInfos, err := prepare.GetDeployInfos(ctx, manifestObj, r.Client, r.VerifyInstallation,
-		r.CustomStateCheck, r.Codec, r.RestConfig)
+		r.CustomStateCheck, r.Codec)
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func (r *ManifestReconciler) HandleReadyState(ctx context.Context, logger *logr.
 
 	// send deploy requests
 	deployInfos, err := prepare.GetDeployInfos(ctx, manifestObj, r.Client, r.VerifyInstallation, r.CustomStateCheck,
-		r.Codec, r.RestConfig)
+		r.Codec)
 	if err != nil {
 		return err
 	}

--- a/operator/internal/pkg/custom/verify.go
+++ b/operator/internal/pkg/custom/verify.go
@@ -3,8 +3,6 @@ package custom
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/rest"
-
 	"github.com/go-logr/logr"
 	"github.com/kyma-project/manifest-operator/operator/api/v1alpha1"
 	"github.com/kyma-project/manifest-operator/operator/pkg/custom"
@@ -12,13 +10,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type CustomResourceCheck struct {
+type Resource struct {
 	DefaultClient client.Client
 	custom.Check
 }
 
-func (c *CustomResourceCheck) CheckProcessingFn(ctx context.Context, manifestLabels map[string]string,
-	namespacedName client.ObjectKey, logger *logr.Logger, defaultRestConfig *rest.Config) (bool, error) {
+func (r *Resource) CheckFn(ctx context.Context, manifestLabels map[string]string,
+	namespacedName client.ObjectKey, logger *logr.Logger) (bool, error) {
 	kymaOwnerLabel, ok := manifestLabels[labels.ComponentOwner]
 	if !ok {
 		err := fmt.Errorf("label %s not set for manifest resource %s", labels.ComponentOwner, namespacedName)
@@ -27,16 +25,18 @@ func (c *CustomResourceCheck) CheckProcessingFn(ctx context.Context, manifestLab
 	}
 
 	// evaluate rest config
-	clusterClient := &custom.ClusterClient{DefaultClient: c.DefaultClient}
-	restConfig, err := clusterClient.GetRestConfig(ctx, kymaOwnerLabel, namespacedName.Namespace, defaultRestConfig)
+	clusterClient := &custom.ClusterClient{DefaultClient: r.DefaultClient}
+	restConfig, err := clusterClient.GetRestConfig(ctx, kymaOwnerLabel, namespacedName.Namespace)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("error while evaluating rest config for manifest resource %s", namespacedName))
+		logger.Error(err, fmt.Sprintf("error while evaluating rest config for manifest resource %s",
+			namespacedName))
 		return false, err
 	}
 
 	customClient, err := clusterClient.GetNewClient(restConfig, client.Options{})
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("error while evaluating target client for manifest resource %s", namespacedName))
+		logger.Error(err, fmt.Sprintf("error while evaluating target client for manifest resource %s",
+			namespacedName))
 		return false, err
 	}
 
@@ -46,13 +46,16 @@ func (c *CustomResourceCheck) CheckProcessingFn(ctx context.Context, manifestLab
 	}
 
 	manifestObj := v1alpha1.Manifest{}
-	if err = c.DefaultClient.Get(ctx, namespacedName, &manifestObj); err != nil {
+	if err = r.DefaultClient.Get(ctx, namespacedName, &manifestObj); err != nil {
 		return false, err
 	}
 
-	ready, err := customStatus.WaitForCustomResources(ctx, manifestObj.Spec.CustomStates)
+	ready, err := customStatus.WaitForCustomResources(ctx, manifestObj.Spec.CustomStates,
+		&manifestObj.Spec.Resource)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("error while tracking status of custom resources for manifest resource %s", namespacedName))
+		logger.Error(err,
+			fmt.Sprintf("error while tracking status of custom resources for manifest %s",
+				namespacedName))
 		return false, err
 	}
 

--- a/operator/pkg/custom/client.go
+++ b/operator/pkg/custom/client.go
@@ -26,7 +26,7 @@ func (cc *ClusterClient) GetNewClient(restConfig *rest.Config, options client.Op
 }
 
 func (cc *ClusterClient) GetRestConfig(ctx context.Context, kymaOwner string, namespace string,
-	defaultRestConfig *rest.Config) (*rest.Config, error) {
+) (*rest.Config, error) {
 	kubeConfigSecretList := &v1.SecretList{}
 	gr := v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)).GroupResource()
 	if err := cc.DefaultClient.List(ctx, kubeConfigSecretList, &client.ListOptions{
@@ -35,8 +35,7 @@ func (cc *ClusterClient) GetRestConfig(ctx context.Context, kymaOwner string, na
 	}); err != nil {
 		return nil, err
 	} else if len(kubeConfigSecretList.Items) < 1 {
-		// return default rest config - components to be installed in-cluster
-		return defaultRestConfig, nil
+		return nil, errors.NewNotFound(gr, "remote cluster kubeconfig")
 	} else if len(kubeConfigSecretList.Items) > 1 {
 		return nil, errors.NewConflict(gr, kymaOwner, fmt.Errorf("more than one instance found"))
 	}

--- a/operator/pkg/custom/function.go
+++ b/operator/pkg/custom/function.go
@@ -2,16 +2,14 @@ package custom
 
 import (
 	"context"
-	"k8s.io/client-go/rest"
-
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type CheckFnType func(ctx context.Context, manifestLabels map[string]string, namespacedName client.ObjectKey,
-	logger *logr.Logger, defaultRestConfig *rest.Config) (bool, error)
+	logger *logr.Logger) (bool, error)
 
 type Check interface {
 	CheckFn(ctx context.Context, manifestLabels map[string]string, namespacedName client.ObjectKey,
-		logger *logr.Logger, defaultRestConfig *rest.Config) (bool, error)
+		logger *logr.Logger) (bool, error)
 }

--- a/operator/pkg/custom/status.go
+++ b/operator/pkg/custom/status.go
@@ -2,8 +2,8 @@ package custom
 
 import (
 	"context"
-	"fmt"
 	"github.com/kyma-project/manifest-operator/operator/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,30 +13,72 @@ type Status struct {
 	client.Reader
 }
 
-func (c *Status) WaitForCustomResources(ctx context.Context, customWaitResource []types.CustomState) (bool, error) {
+//TODO: Define centrally
+const readyState = "Ready"
+
+func (c *Status) WaitForCustomResources(ctx context.Context, customWaitResource []types.CustomState,
+	stateResource *unstructured.Unstructured) (bool, error) {
+
+	// custom states
 	for _, res := range customWaitResource {
-		obj := unstructured.Unstructured{}
+		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion(res.APIVersion)
 		obj.SetKind(res.Kind)
 		namespacedName := client.ObjectKey{Name: res.Name, Namespace: res.Namespace}
-		if err := c.Get(ctx, namespacedName, &obj); client.IgnoreNotFound(err) != nil {
+
+		// if not found or any misc error occurred - return!
+		if err := c.Get(ctx, namespacedName, obj); err != nil {
 			return false, err
 		}
 
-		status, ok := obj.Object["status"]
-		if !ok {
-			return false, fmt.Errorf(".status object not found for %s", namespacedName.String())
+		state, err := getStateFieldFromUnstructured(obj)
+		if err != nil {
+			return false, err
 		}
 
-		state, ok := status.(map[string]interface{})["state"]
-		if !ok {
-			return false, fmt.Errorf(".status.state not found for %s", namespacedName.String())
+		if state != res.State {
+			return false, nil
+		}
+	}
+
+	// resource
+	if stateResource != nil {
+		existingStateResource := &unstructured.Unstructured{}
+		existingStateResource.SetGroupVersionKind(stateResource.GroupVersionKind())
+		customResourceKey := client.ObjectKey{
+			Name:      stateResource.GetName(),
+			Namespace: stateResource.GetNamespace(),
 		}
 
-		if state.(string) != res.State {
+		// if not found or any misc error occurred - return!
+		if err := c.Get(ctx, customResourceKey, existingStateResource); err != nil {
+			return false, err
+		}
+
+		state, err := getStateFieldFromUnstructured(existingStateResource)
+		if err != nil {
+			return false, err
+		}
+
+		if state != readyState {
 			return false, nil
 		}
 	}
 
 	return true, nil
+}
+
+func getStateFieldFromUnstructured(resource *unstructured.Unstructured) (string, error) {
+	path := field.NewPath("status")
+	status, ok := resource.Object["status"]
+	if !ok {
+		return "", field.NotFound(path, resource.Object)
+	}
+
+	path = path.Child("state")
+	state, ok := status.(map[string]interface{})["state"]
+	if !ok {
+		return "", field.NotFound(path, resource.Object)
+	}
+	return state.(string), nil
 }

--- a/operator/pkg/manifest/operations.go
+++ b/operator/pkg/manifest/operations.go
@@ -136,7 +136,7 @@ func (o *Operations) VerifyResources(deployInfo DeployInfo) (bool, error) {
 		return true, nil
 	}
 	return deployInfo.CheckFn(deployInfo.Ctx, deployInfo.ManifestLabels, deployInfo.ObjectKey,
-		o.logger, deployInfo.RestConfig)
+		o.logger)
 }
 
 func (o *Operations) Install(deployInfo DeployInfo) (bool, error) {
@@ -177,7 +177,7 @@ func (o *Operations) Install(deployInfo DeployInfo) (bool, error) {
 	// check custom function, if provided
 	if deployInfo.CheckFn != nil {
 		return deployInfo.CheckFn(deployInfo.Ctx, deployInfo.ManifestLabels, deployInfo.ObjectKey,
-			o.logger, deployInfo.RestConfig)
+			o.logger)
 	}
 
 	return true, nil
@@ -214,7 +214,7 @@ func (o *Operations) Uninstall(deployInfo DeployInfo) (bool, error) {
 	// check custom function, if provided
 	if deployInfo.CheckFn != nil {
 		return deployInfo.CheckFn(deployInfo.Ctx, deployInfo.ManifestLabels, deployInfo.ObjectKey,
-			o.logger, deployInfo.RestConfig)
+			o.logger)
 	}
 
 	return true, nil


### PR DESCRIPTION
- Make `.spec.resource` optional
- Make `.spec.crds` optional
- Remove default client config as fallback if secret with kubeconfig not found
- Verify state of `.spec.resource` as "Ready" if flag set `--custom-state-check=true`
- Misc refactoring